### PR TITLE
ResStock data fetcher library

### DIFF
--- a/lib/fetch_resstock_data/daily_2022.sql
+++ b/lib/fetch_resstock_data/daily_2022.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS daily_2022;
+CREATE TABLE daily_2022 AS (
+  SELECT * FROM read_parquet('/workspaces/reports/data/ResStock/temp/athena_daily_results.parquet')
+);

--- a/lib/fetch_resstock_data/hourly_2022.sql
+++ b/lib/fetch_resstock_data/hourly_2022.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS hourly_2022;
+CREATE TABLE hourly_2022 AS (
+  SELECT * FROM read_parquet('/workspaces/reports/data/ResStock/temp/athena_hourly_results.parquet')
+);

--- a/lib/fetch_resstock_data/load_2022_release.sql
+++ b/lib/fetch_resstock_data/load_2022_release.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS housing_units;
+DROP TABLE IF EXISTS annuals_results;
+
+CREATE TABLE housing_units AS (
+  WITH tmp AS (
+    SELECT * FROM read_csv_auto('/workspaces/ochre-sims/data/building_energy_models/2022_resstock_amy2018_release_1.1/' || getenv('STATE') || '_baseline_metadata_and_annual_results.csv')
+  )
+  SELECT bldg_id, weight, COLUMNS(c -> c LIKE 'in%') from tmp
+);
+
+CREATE TABLE annuals_results AS (
+  WITH u3 AS (
+    SELECT * FROM read_csv_auto('/workspaces/ochre-sims/data/building_energy_models/2022_resstock_amy2018_release_1.1/' || getenv('STATE') || '_upgrade03_metadata_and_annual_results.csv')
+  ),
+  u4 AS (
+    SELECT * FROM read_csv_auto('/workspaces/ochre-sims/data/building_energy_models/2022_resstock_amy2018_release_1.1/' || getenv('STATE') || '_upgrade04_metadata_and_annual_results.csv')
+  ),
+  baseline AS (
+    SELECT * FROM read_csv_auto('/workspaces/ochre-sims/data/building_energy_models/2022_resstock_amy2018_release_1.1/' || getenv('STATE') || '_baseline_metadata_and_annual_results.csv')
+  ),
+  combo AS (
+    SELECT * FROM u3
+    UNION ALL BY NAME SELECT * FROM u4
+    UNION ALL BY NAME SELECT * FROM baseline
+  )
+  SELECT bldg_id, COLUMNS(c -> c LIKE 'out%'), COLUMNS(c -> c LIKE 'upgrade%')
+  FROM combo
+);
+
+-- CREATE TABLE time_series AS (
+--   WITH tmp AS (
+--     SELECT * FROM read_csv_auto('/workspace/reports/data/resstock/2022_resstock_amy2018_release_1.1/resstock_monthly_totals_ny.csv')
+--   )
+--   SELECT *
+--   FROM tmp
+-- );

--- a/lib/fetch_resstock_data/load_2024_NY_release.sql
+++ b/lib/fetch_resstock_data/load_2024_NY_release.sql
@@ -1,0 +1,21 @@
+CREATE TABLE housing_units AS (
+  WITH tmp AS (
+    SELECT * FROM read_csv_auto('/workspaces/reports/data/resstock/2024_resstock_amy2018_release_2/NY_baseline_metadata_and_annual_results.csv')
+  )
+  SELECT bldg_id, weight, COLUMNS(c -> c LIKE 'in%') from tmp
+);
+
+CREATE TABLE simulations AS (
+  WITH u4 AS (
+    SELECT * FROM read_csv_auto('/workspaces/reports/data/resstock/2024_resstock_amy2018_release_2/NY_upgrade04_metadata_and_annual_results.csv')
+  ),
+  baseline AS (
+    SELECT * FROM read_csv_auto('/workspaces/reports/data/resstock/2024_resstock_amy2018_release_2/NY_baseline_metadata_and_annual_results.csv')
+  ),
+  combo AS (
+    SELECT * FROM u4
+    UNION ALL BY NAME SELECT * FROM baseline
+  )
+  SELECT bldg_id, applicability, COLUMNS(c -> c LIKE 'out%'), COLUMNS(c -> c LIKE 'upgrade%')
+  FROM combo
+);

--- a/lib/fetch_resstock_data/monthly_2022.sql
+++ b/lib/fetch_resstock_data/monthly_2022.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS monthly_2022;
+CREATE TABLE monthly_2022 AS (
+  SELECT * FROM read_parquet('/workspaces/reports/data/ResStock/temp/athena_monthly_results.parquet')
+);

--- a/lib/fetch_resstock_data/resstock_2022_athena.py
+++ b/lib/fetch_resstock_data/resstock_2022_athena.py
@@ -1,0 +1,864 @@
+import sys
+import io
+import os
+import time
+import json
+import pyarrow.parquet as pq
+import pandas as pd
+from pathlib import Path
+import argparse
+import duckdb
+# AWS
+import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
+
+# AWS Session
+session = boto3.Session(profile_name="switchbox")
+s3_client = session.client("s3")
+athena_client = session.client("athena", region_name="us-west-2")
+
+# S3 Paths
+aws_database = "euss_oedi"
+bucket = "dummy-123-target"
+folder = "dummy_athena_queries"
+
+
+def drop_table(
+    athena_client: boto3.client,
+    aws_database: str,
+    table_name: str,
+):
+
+    drop_query = f"DROP TABLE IF EXISTS {aws_database}.{table_name}"
+    print(f"Attempting to drop table: {drop_query}")
+    drop_response = athena_client.start_query_execution(
+        QueryString=drop_query,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": f"s3://{bucket}/{folder}/temp"},
+    )
+
+    # Wait for drop query to complete
+    while True:
+        drop_status = athena_client.get_query_execution(
+            QueryExecutionId=drop_response["QueryExecutionId"]
+        )
+        drop_state = drop_status["QueryExecution"]["Status"]["State"]
+
+        if drop_state == "SUCCEEDED":
+            print(f"    -> Dropped!")
+            break
+        elif drop_state == "FAILED":
+            raise Exception(f"Failed to drop table: {table_name}")
+        elif drop_state == "CANCELLED":
+            raise Exception(f"Cancelled drop query for table: {table_name}")
+
+        time.sleep(0.5)
+
+    return drop_state
+
+
+###############################################################################
+# Old Method
+def generate_athena_query_string(
+    state: str,
+    upgrade: str,
+    p2columns: str = None,
+    agg_frequency: str = "month",
+    verbose: bool = False,
+    s3_output_location: str = None,
+) -> str:
+
+    limit = 10
+    timestamp = time.strftime("%m_%d_%H%M")
+
+    s3_output_location = f"s3://{bucket}/{folder}/temp/{timestamp}"
+
+    # if agg_frequency not in ['date' 'month', 'year']:
+    # raise ValueError(f"Invalid aggregation frequency: '{agg_frequency}'. Should be ['date', 'month']"
+    print(agg_frequency)
+
+    if p2columns:
+        with open((p2columns), "r") as f:
+            columns = json.load(f)
+
+    if p2columns is None:
+        columns = [
+            "out.electricity.total.energy_consumption",
+            "out.fuel_oil.total.energy_consumption",
+            "out.natural_gas.total.energy_consumption",
+            "out.propane.total.energy_consumption",
+            "out.site_energy.net.energy_consumption",
+            "out.site_energy.total.energy_consumption",
+        ]
+
+    # Create the column selections and sum expressions
+    column_selects = ",\n            ".join(f'"{col}"' for col in columns)
+    sum_expressions = ",\n          ".join(
+        f'SUM("{col}") as "sum_{col}"' for col in columns
+    )
+
+    # Convert agg_frequency to string if it's not already
+    if agg_frequency == "month":
+        extract_statement = 'EXTRACT(month FROM "timestamp") as month'
+    elif agg_frequency == "date":
+        # extract_statement = "(DATE('timestamp') - '15' minute) as date"
+        extract_statement = (
+            """DATE_ADD('minute', -15, CAST("timestamp" AS timestamp)) as date"""
+        )
+    elif agg_frequency == "hour":
+        # For 8760 unique hours, we need both the date and hour
+        # extract_statement = """DATE("timestamp") || ' ' ||
+        #         LPAD(CAST(EXTRACT(HOUR FROM "timestamp") as VARCHAR), 2, '0')
+        #         as hour"""
+        extract_statement = (
+            """DATE_ADD('minute', -15, CAST("timestamp" AS timestamp)) as date"""
+        )
+
+    # DROP TABLE IF EXISTS euss_oedi.temp_{state}_{upgrade}_{agg_frequency};
+    # external_location = '{s3_output_location}/temp_{state}_{upgrade}_{agg_frequency}',
+    query = f"""
+    CREATE TABLE euss_oedi.temp_{timestamp}
+    WITH (
+        format = 'PARQUET',
+        write_compression = 'SNAPPY',
+        external_location = '{s3_output_location}',
+        bucketed_by = ARRAY['bldg_id'],
+        bucket_count = 1
+    ) AS
+    WITH base_data AS (
+    SELECT 
+        bldg_id,
+        {extract_statement},
+        upgrade,
+        {column_selects}
+    FROM "euss_oedi"."res_amy18_r1_by_state"
+    WHERE "state" = '{state}'
+    AND "upgrade" = '{upgrade}'
+    )
+    SELECT 
+    bldg_id,
+    {agg_frequency},
+    upgrade,
+    {sum_expressions}
+    FROM base_data
+    GROUP BY bldg_id, {agg_frequency}, upgrade
+    ORDER BY bldg_id, {agg_frequency};
+    """
+
+    if verbose:
+        print(query)
+
+    return query, timestamp
+
+
+def get_athena_query_results_as_parquet(
+    s3_client: boto3.client,
+    athena_client: boto3.client,
+    timestamp: str,
+    query_string: str,
+    aws_database: str,
+    s3_output_location: str,
+    local_parquet_path: str,
+):
+    """
+    Run Athena query and save results as local Parquet file
+    """
+
+    print(f"S3 output location: {s3_output_location}")
+
+    # --------------------------------------------------------------------------
+    # First, delete the table if it exists
+    # Drop the table if it exists
+    drop_query = f"DROP TABLE IF EXISTS {aws_database}.temp_{timestamp}"
+    print(f"Dropping table: {drop_query}")
+    drop_response = athena_client.start_query_execution(
+        QueryString=drop_query,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    # Wait for drop query to complete
+    while True:
+        drop_status = athena_client.get_query_execution(
+            QueryExecutionId=drop_response["QueryExecutionId"]
+        )
+        drop_state = drop_status["QueryExecution"]["Status"]["State"]
+
+        if drop_state in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        time.sleep(1)
+        print(f"Dropped!")
+
+    # --------------------------------------------------------------------------
+    # Now, the interesting ResStock query
+    print(f"Running query: {query_string}")
+    response = athena_client.start_query_execution(
+        QueryString=query_string,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    # Wait for query to complete
+    start_time = time.time()
+    while True:
+        query_status = athena_client.get_query_execution(
+            QueryExecutionId=response["QueryExecutionId"]
+        )
+        q_state = query_status["QueryExecution"]["Status"]["State"]
+
+        if q_state in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        elapsed_time = time.time() - start_time  # Calculate elapsed time
+
+        sys.stdout.write(f"\r{q_state} ({elapsed_time:.1f}s)")
+        sys.stdout.flush()
+
+        time.sleep(1)
+
+    if q_state != "SUCCEEDED":
+        raise Exception(f"Query failed with state: {q_state}")
+
+    print(f"\n\nStatus: {q_state}")
+
+    # --------------------------------------------------------------------------
+    # Get the S3 bucket and key from the output location
+    # Locate the file within s3
+    print(f"Bucket: {bucket}")
+    print(f"Folder: {folder}")
+
+    p2temp = folder + f"/temp"
+    print(f"p2temp: {p2temp}")
+
+    p2timestamp = folder + f"/temp/{timestamp}"
+    print(f"p2timestamp: {p2timestamp}")
+
+    # List all objects in the s3_output_location
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=p2timestamp)
+
+    # Download each file found
+    for page in pages:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                obj_key = obj["Key"]
+                # Skip metadata files
+                excluded_endings = [".metadata", ".csv"]
+                if not any(obj_key.endswith(ending) for ending in excluded_endings):
+                    print(f"Downloading {obj_key} to {local_parquet_path}")
+                    s3_client.download_file(
+                        Bucket=bucket, Key=obj_key, Filename=local_parquet_path
+                    )
+
+    # --------------------------------------------------------------------------
+    # Optional: Clean up S3 results
+
+    # drop the table from the database
+    drop_query = f"DROP TABLE IF EXISTS {aws_database}.temp_{timestamp}"
+    print(f"Dropping table: {drop_query}")
+    drop_response = athena_client.start_query_execution(
+        QueryString=drop_query,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    while True:
+        drop_status = athena_client.get_query_execution(
+            QueryExecutionId=drop_response["QueryExecutionId"]
+        )
+        drop_state = drop_status["QueryExecution"]["Status"]["State"]
+
+        if drop_state in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        time.sleep(1)
+
+    # Delete all objects in the temp folder
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=p2temp)
+
+    for page in pages:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                s3_client.delete_object(Bucket=bucket, Key=obj["Key"])
+
+
+###############################################################################
+# New Method
+def build_intermediate_table(
+    state: str,
+    upgrade: str,
+    s3_client: boto3.client,
+    athena_client: boto3.client,
+    aws_database: str,
+    s3_output_location: str,
+    p2columns: str = None,
+) -> str:
+
+    intermediate_table = f"{state}_mdh_cols"
+    
+    
+    if p2columns:
+        with open((p2columns), "r") as f:
+            columns = json.load(f)
+
+    if p2columns is None:
+        columns = [
+            "out.electricity.total.energy_consumption",
+            "out.fuel_oil.total.energy_consumption",
+            "out.natural_gas.total.energy_consumption",
+            "out.propane.total.energy_consumption"
+        ]
+
+    # --------------------------------------------------------------------------
+    # 2. Drop the table if it exists
+    print(f"\n1. Dropping existing table ({intermediate_table})")
+    drop_table(
+        athena_client=athena_client,
+        aws_database=aws_database,
+        table_name=intermediate_table,
+    )
+    
+
+    # --------------------------------------------------------------------------
+    # 2. Write the query
+    
+    # Create the column selections and sum expressions
+    if p2columns:
+        with open((p2columns), "r") as f:
+            columns = json.load(f)
+
+    if p2columns is None:
+        columns = [
+            "out.electricity.total.energy_consumption",
+            "out.fuel_oil.total.energy_consumption",
+            "out.natural_gas.total.energy_consumption",
+            "out.propane.total.energy_consumption"
+        ]
+    
+    column_selects = ",\n            ".join(f'"{col}"' for col in columns)
+    
+    query_string = f"""
+    CREATE TABLE {aws_database}.{intermediate_table} AS
+    SELECT 
+        bldg_id,
+        upgrade,
+        EXTRACT(MONTH FROM adjusted_time) as month,
+        EXTRACT(DAY FROM adjusted_time) as day,
+        EXTRACT(HOUR FROM adjusted_time) as hour,
+        {column_selects}
+    FROM (
+        SELECT 
+            *,
+            DATE_ADD('minute', -15, CAST("timestamp" AS timestamp)) as adjusted_time
+        FROM "euss_oedi"."res_amy18_r1_by_state"
+        WHERE state = '{state.upper()}'
+        AND upgrade IN ({','.join([f"'{u}'" for u in upgrade])})
+        );
+    """
+
+    print(f"\n2. Query to build Intermediate table ({intermediate_table})")
+    print(query_string)
+
+
+    # --------------------------------------------------------------------------
+    # 3. Run the query
+    print(f"3. Now running the query intermediate table...")
+    response = athena_client.start_query_execution(
+        QueryString=query_string,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    start_time = time.time()
+    while True:
+        query_status = athena_client.get_query_execution(
+            QueryExecutionId=response["QueryExecutionId"]
+        )
+        q_status = query_status["QueryExecution"]["Status"]["State"]
+
+        if q_status in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        elapsed_time = time.time() - start_time  # Calculate elapsed time
+
+        sys.stdout.write(f"\r{q_status} ({elapsed_time:.1f}s)")
+        sys.stdout.flush()
+
+        time.sleep(1)
+
+    if q_status == "SUCCEEDED":
+        print(f"\n\nQuery Succeeded (Status: {q_status})")
+    else:
+        raise Exception(f"Query failed with q_status: {q_status}")
+
+    return f"{aws_database}.{intermediate_table}"
+
+
+def monthly_query(
+    intermediate_table: str,
+    state: str,
+    upgrade: str,
+    s3_client: boto3.client,
+    athena_client: boto3.client,
+    aws_database: str,
+    s3_output_location: str,
+    local_parquet_path: str,
+    duckdb_path: str,
+    p2columns: str = None,
+):
+
+    monthly_table = f"{state}_monthly"
+
+    # Clean up existing files in the target S3 location
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=f"summaries/{state}/monthly")
+
+    for page in pages:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                s3_client.delete_object(Bucket=bucket, Key=obj["Key"])
+
+    # --------------------------------------------------------------------------
+    drop_query = f"DROP TABLE IF EXISTS {aws_database}.{monthly_table}"
+    drop_table(
+        athena_client=athena_client, aws_database=aws_database, table_name=monthly_table
+    )
+
+    # --------------------------------------------------------------------------
+    if p2columns:
+        with open((p2columns), "r") as f:
+            columns = json.load(f)
+
+    if p2columns is None:
+        columns = [
+            "out.electricity.total.energy_consumption",
+            "out.fuel_oil.total.energy_consumption",
+            "out.natural_gas.total.energy_consumption",
+            "out.propane.total.energy_consumption",
+            "out.site_energy.net.energy_consumption",
+            "out.site_energy.total.energy_consumption",
+        ]
+
+    # Create the column selections and sum expressions
+    column_selects = ",\n            ".join(f'"{col}"' for col in columns)
+    sum_expressions = ",\n          ".join(
+        f'SUM("{col}") as "sum_{col}"' for col in columns
+    )
+
+    query_string = f"""
+    CREATE TABLE {monthly_table}
+    WITH (
+        format = 'PARQUET',
+        write_compression = 'SNAPPY',
+        external_location = 's3://dummy-123-target/summaries/{state}/monthly'
+    ) AS
+    SELECT 
+        bldg_id,
+        month,
+        upgrade,
+        {sum_expressions}
+    FROM {intermediate_table}
+    GROUP BY bldg_id, upgrade, month
+    ORDER BY bldg_id, upgrade, month;
+    """
+
+    print(query_string)
+
+    print(f"Running query: {query_string}")
+    response = athena_client.start_query_execution(
+        QueryString=query_string,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    # Wait for query to complete
+    start_time = time.time()
+    while True:
+        query_status = athena_client.get_query_execution(
+            QueryExecutionId=response["QueryExecutionId"]
+        )
+        q_status = query_status["QueryExecution"]["Status"]["State"]
+
+        if q_status in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        elapsed_time = time.time() - start_time  # Calculate elapsed time
+
+        sys.stdout.write(f"\r{q_status} ({elapsed_time:.1f}s)")
+        sys.stdout.flush()
+
+        time.sleep(1)
+
+    if q_status != "SUCCEEDED":
+        raise Exception(f"Query failed with q_status: {q_status}")
+
+    print(f"\n\nStatus: {q_status}")
+
+    # --------------------------------------------------------------------------
+    # Get the S3 bucket and key from the output location
+    # Locate the file within s3
+    print(f"Bucket: {bucket}")
+    print(f"Folder: {folder}")
+
+    p2temp = folder + f"/temp"
+    print(f"p2temp: {p2temp}")
+
+    # p2timestamp = folder + f"/temp/{timestamp}"
+    # print(f"p2timestamp: {p2timestamp}")
+    summaries_folder = f"summaries/{state}/monthly"
+    print(f"Summaries folder: {summaries_folder}")
+
+    # List all objects in the s3_output_location
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=summaries_folder)
+    print(f"Pages: {pages}")
+
+    # Download each file found
+    for page in pages:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                obj_key = obj["Key"]
+                # Skip metadata files
+                excluded_endings = [".metadata", ".csv"]
+                if not any(obj_key.endswith(ending) for ending in excluded_endings):
+                    print(f"Downloading {obj_key} to {local_parquet_path}")
+                    s3_client.download_file(
+                        Bucket=bucket, Key=obj_key, Filename=local_parquet_path
+                    )
+
+    # --------------------------------------------------------------------------
+    # Optional: Clean up S3 results
+
+    # drop the table from the database
+    drop_query = f"DROP TABLE IF EXISTS {monthly_table}"
+    print(f"Dropping table: {drop_query}")
+    drop_response = athena_client.start_query_execution(
+        QueryString=drop_query,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    while True:
+        drop_status = athena_client.get_query_execution(
+            QueryExecutionId=drop_response["QueryExecutionId"]
+        )
+        drop_state = drop_status["QueryExecution"]["Status"]["State"]
+
+        if drop_state in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        time.sleep(1)
+
+    # Delete all objects in the temp folder
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=p2temp)
+
+    for page in pages:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                s3_client.delete_object(Bucket=bucket, Key=obj["Key"])
+
+ 
+def hourly_query(
+    intermediate_table: str,
+    state: str,
+    upgrade: str,
+    s3_client: boto3.client,
+    athena_client: boto3.client,
+    aws_database: str,
+    s3_output_location: str,
+    local_parquet_path: str,
+    duckdb_path: str,
+    p2columns: str = None,
+    download_via: str = "direct_to_duckdb",
+    drop_table_after_query: bool = False,
+):
+    
+    hourly_table = f"{state}_hourly"
+    
+    # --------------------------------------------------------------------------
+    # 1. Clean up existing files in the target S3 location
+    
+    
+    print(f"\n1. Cleaning up existing files in the target S3 location")
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=f"summaries/{state}/hourly")
+
+    for page in pages:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                s3_client.delete_object(Bucket=bucket, Key=obj["Key"])
+                
+
+    drop_query = f"DROP TABLE IF EXISTS {aws_database}.{hourly_table}"
+    drop_table(
+        athena_client=athena_client, aws_database=aws_database, table_name=hourly_table
+    )
+
+    # --------------------------------------------------------------------------
+    # 2. Write the query
+    print(f"\n2. Writing the query")
+    if p2columns:
+        with open((p2columns), "r") as f:
+            columns = json.load(f)
+
+    if p2columns is None:
+        columns = [
+            "out.electricity.total.energy_consumption",
+            "out.fuel_oil.total.energy_consumption",
+            "out.natural_gas.total.energy_consumption",
+            "out.propane.total.energy_consumption"
+        ]
+
+    # Create the column selections and sum expressions      
+    column_selects = ",\n            ".join(f'"{col}"' for col in columns)
+    sum_expressions = ",\n          ".join(
+        f'SUM("{col}") as "sum_{col}"' for col in columns
+    )   
+    
+    query_string = f"""
+    CREATE TABLE {hourly_table}
+    WITH (
+        format = 'PARQUET',
+        write_compression = 'SNAPPY',
+        external_location = 's3://dummy-123-target/summaries/{state}/hourly'
+    ) AS        
+    SELECT 
+        bldg_id,
+        upgrade,
+        month,
+        day,
+        hour,
+        {sum_expressions}
+    FROM {intermediate_table}
+    GROUP BY bldg_id, upgrade, month, day, hour
+    ORDER BY bldg_id, upgrade, month, day, hour;
+    """
+
+    print(f"3. Running query: {query_string}")
+    response = athena_client.start_query_execution(
+        QueryString=query_string,
+        QueryExecutionContext={"Database": aws_database},
+        ResultConfiguration={"OutputLocation": s3_output_location},
+    )
+
+    # Wait for query to complete
+    start_time = time.time()    
+    while True:
+        query_status = athena_client.get_query_execution(
+            QueryExecutionId=response["QueryExecutionId"]
+        )
+        q_status = query_status["QueryExecution"]["Status"]["State"]        
+
+        if q_status in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+            break
+
+        elapsed_time = time.time() - start_time  # Calculate elapsed time
+
+        sys.stdout.write(f"\r{q_status} ({elapsed_time:.1f}s)")
+        sys.stdout.flush()
+
+        time.sleep(1)
+
+    if q_status == "SUCCEEDED":
+        print(f"\n\nQuery Succeeded (Status: {q_status})")
+    else:
+        raise Exception(f"Query failed with q_status: {q_status}") 
+
+    # --------------------------------------------------------------------------
+    # Get the S3 bucket and key from the output location
+    # Locate the file within s3
+    print(f"\n4. Downloading via {download_via}")
+    print(f"Bucket: {bucket}")
+    print(f"Folder: {folder}")          
+
+    summaries_folder = f"summaries/{state}/hourly"
+    print(f"Summaries folder: {summaries_folder}")          
+    
+    if download_via == "paginator":
+        # List all objects in the s3_output_location
+        print(f"Downloading files via paginator")
+        paginator = s3_client.get_paginator("list_objects_v2")
+        pages = paginator.paginate(Bucket=bucket, Prefix=summaries_folder)
+        print(f"Pages: {pages}")    
+
+        # Download each file found
+        for page in pages:
+            if "Contents" in page:
+                for obj in page["Contents"]:
+                    obj_key = obj["Key"]
+                    # Skip metadata files
+                    excluded_endings = [".metadata", ".csv"]                        
+                    if not any(obj_key.endswith(ending) for ending in excluded_endings):
+                        print(f"Downloading {obj_key} to {local_parquet_path}")
+                        s3_client.download_file(
+                            Bucket=bucket, Key=obj_key, Filename=local_parquet_path
+                        )
+    
+    elif download_via == "direct_to_duckdb":
+        print(f"Downloading files directly to DuckDB")
+        conn = duckdb.connect(duckdb_path)
+        conn.execute("INSTALL httpfs")
+        conn.execute("LOAD httpfs")
+        
+        # Set your AWS credentials if needed
+        conn.execute(f"SET s3_access_key_id='{session.get_credentials().access_key}'")
+        conn.execute(f"SET s3_secret_access_key='{session.get_credentials().secret_key}'")
+        conn.execute(f"SET s3_region='{session.region_name}'")
+        
+        conn.execute(f"""
+            CREATE TABLE {hourly_table} AS
+            SELECT * FROM read_parquet('s3://dummy-123-target/summaries/{state}/hourly/*')
+            """)
+        
+    else:
+        raise ValueError(f"Invalid download method: '{download_via}'. Should be ['paginator', 'direct_to_duckdb']")
+    # --------------------------------------------------------------------------
+
+   # --------------------------------------------------------------------------
+    # Optional: Clean up S3 results   
+    if drop_table_after_query:  
+        print(f"\n5. Dropping the table from the database")
+        drop_query = f"DROP TABLE IF EXISTS {hourly_table}"
+        print(f"Dropping table: {drop_query}")  
+        drop_response = athena_client.start_query_execution(
+            QueryString=drop_query,
+            QueryExecutionContext={"Database": aws_database},
+            ResultConfiguration={"OutputLocation": s3_output_location},
+        )
+
+        while True:
+            drop_status = athena_client.get_query_execution(
+                QueryExecutionId=drop_response["QueryExecutionId"]
+            )
+            drop_state = drop_status["QueryExecution"]["Status"]["State"]
+
+            if drop_state in ["SUCCEEDED", "FAILED", "CANCELLED"]:
+                break
+
+            time.sleep(1)
+
+        # Delete all objects in the temp folder
+        paginator = s3_client.get_paginator("list_objects_v2")
+        pages = paginator.paginate(Bucket=bucket, Prefix=p2temp)
+
+        for page in pages:
+            if "Contents" in page:
+                for obj in page["Contents"]:
+                    s3_client.delete_object(Bucket=bucket, Key=obj["Key"])
+    else:
+        print(f"\n4. Skipping dropping the table from the database")
+
+
+###############################################################################
+def main():
+
+    parser = argparse.ArgumentParser(description="Query ResStock data from Athena")
+
+    # Saved for later...passing particular bldg_ids
+    # parser.add_argument('--building-ids', type=int, nargs='+', required=True,
+    #                   help='List of building IDs to query')
+
+    parser.add_argument(
+        "--parquet_path",
+        type=str,
+        default="../data/resstock/temp",
+        help="Path to save the query results locally (default: '../data/resstock/temp')",
+    )
+    parser.add_argument(
+        "--duckdb_path",
+        type=str,
+        default="../data/resstock/temp/resstock_temp.db",
+        help="Path to save the query results locally (default: '../data/resstock/temp/resstock_temp.db')",
+    )
+    parser.add_argument(
+        "--state", type=str, default="MA", help="State to query (default: MA)"
+    )
+    parser.add_argument(
+        "--upgrade", type=int, nargs="+", default=[0], help="Upgrade scenario (default: '0')"
+    )
+    parser.add_argument(
+        "--columns",
+        type=str,
+        default=None,
+        help="Path to a JSON which is simply a list of columns to query",
+    )
+    parser.add_argument(
+        "--agg_frequency",
+        type=str,
+        default="month",
+        help="Aggregation frequency (default: month)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=True,
+        help="Print verbose output including the generated query",
+    )
+
+    args = parser.parse_args()
+    
+    print(args.upgrade)
+
+    # ---------------------------------------------------
+    # Executing the 2-Step Query
+
+    # Step 1: Intermediate table
+    print("\n--------------------------------")
+    print("Building intermediate table")
+    print("--------------------------------")
+    table_name = build_intermediate_table(
+        state=args.state.upper(),
+        upgrade=args.upgrade,
+        s3_client=s3_client,
+        athena_client=athena_client,
+        aws_database=aws_database,
+        s3_output_location=f"s3://{bucket}/{folder}/temp",
+        p2columns=args.columns,
+    )
+
+    print(f"\nDone with intermediate table: {table_name}")
+    print("--------------------------------\n")
+
+    # Step 2: Generate the query string
+    if args.agg_frequency == "month":
+        print("\n--------------------------------")
+        print("Running monthly query")
+        print("--------------------------------")
+        monthly_query(
+            intermediate_table=table_name,
+            state=args.state.upper(),
+            upgrade=args.upgrade,
+            s3_client=s3_client,
+            athena_client=athena_client,
+            aws_database=aws_database,
+            s3_output_location=f"s3://{bucket}/{folder}/temp",
+            local_parquet_path=args.parquet_path,
+            p2columns=args.columns,
+        )
+    elif args.agg_frequency == "hour":
+        print("\n--------------------------------")
+        print("Running hourly query")
+        print("--------------------------------")
+        hourly_query(
+            intermediate_table=table_name,
+            state=args.state.upper(),
+            upgrade=args.upgrade,
+            s3_client=s3_client,
+            athena_client=athena_client,
+            aws_database=aws_database,
+            s3_output_location=f"s3://{bucket}/{folder}/temp",
+            local_parquet_path=args.parquet_path,
+            duckdb_path=args.duckdb_path,
+            p2columns=args.columns,
+        )
+        print("\nDone with hourly query")
+        print("--------------------------------")
+    else:
+        raise ValueError(f"Invalid aggregation frequency: '{args.agg_frequency}'. Should be ['month', 'hour']")
+
+if __name__ == "__main__":
+    main()

--- a/lib/fetch_resstock_data/resstock_fetch_data.py
+++ b/lib/fetch_resstock_data/resstock_fetch_data.py
@@ -1,0 +1,121 @@
+import os
+import csv
+import requests
+import zipfile
+from datetime import date
+from ochre import Analysis
+#AWS
+import boto3
+from botocore.config import Config
+from botocore import UNSIGNED
+
+"""
+Code for downloading resstock data such as building xml, previously performed simulation timeseries
+
+Author: Alex Lee (alexlee5124@gmail.com)
+Date: 3/29/2025
+
+"""
+
+
+URL_BASE = "https://oedi-data-lake.s3.amazonaws.com/nrel-pds-building-stock/end-use-load-profiles-for-us-building-stock"
+
+def fetch_building_xml(
+        state:str,
+        upgrade:int,
+        year=2022,
+        version="resstock_amy2018_release_1.1",
+):
+    """
+    fetch_building_xml: This function downloads the building XML file (which holds meta data for a particular building, such as
+    building envelope info, weather station, type of HVAC equipment, etc.). the XML file is filtered by state, upgrade id, 
+    year of published date, and version. This function will download all the available building xml files for that state, upgrade id, published 
+    year, and version.
+
+    Author: Alex Lee (alexlee5124@gmail.com)
+    Date: 3/29/2025
+    """
+
+    # Create directories for saving data. Save building xml's to /ochre-sims/data/building_energy_models/state_year_version
+    building_data_path = os.path.join(os.path.dirname(os.path.dirname(os.getcwd())), f"data/building_energy_models/{state}_{year}_{version}")
+    os.makedirs(building_data_path, exist_ok=True)
+
+    # Fetch and save metadata information for given state, upgrade, and year. Metadata contains building id and upgrade id
+    building_url = f"{URL_BASE}/{year}/{version}/metadata_and_annual_results/by_state/state={state}/csv/{state}_upgrade{upgrade:02d}_metadata_and_annual_results.csv"
+    response = requests.get(building_url)
+    response.raise_for_status()
+    with open(f"{building_data_path}/{state}_upgrade{upgrade:02d}_metadata_and_annual_results.csv", "wb") as file:
+        file.write(response.content)
+
+    # Read in building metadata, extract out building and upgrade id. Save these to a list of dictionaries with keys "bldg_id" and "upgrade"
+    buildingList = []
+    with open(f"{building_data_path}/{state}_upgrade{upgrade:02d}_metadata_and_annual_results.csv", mode="r", encoding="utf-8") as file:
+        reader = csv.DictReader(file)
+        headers = reader.fieldnames[:2]
+        for row in reader:
+            buildingList.append({headers[0]: row[headers[0]], headers[1]: row[headers[1]]})
+    os.remove(f"{building_data_path}/{state}_upgrade{upgrade:02d}_metadata_and_annual_results.csv") # Remove metadata .csv
+
+    # Download buiilding XML files
+    date_string = date.today().strftime("%Y%m%d")
+    for ResStockBuilding in buildingList:
+        building_id = int(ResStockBuilding["bldg_id"])
+        upgrade_id = int(ResStockBuilding["upgrade"])
+        # Create new directory for each building
+        current_building_path = f"{building_data_path}/bldg{building_id:07}-up{upgrade_id:02}"
+        os.makedirs(current_building_path, exist_ok=True)
+        # Download resstock building xml and schedule file. Note that some buildings have missing schedule files.
+        oedi_path = "/".join(["nrel-pds-building-stock","end-use-load-profiles-for-us-building-stock",str(year),
+                version,"building_energy_models",f"upgrade={upgrade_id}",f"bldg{building_id:07}-up{upgrade_id:02}.zip",])
+        s3_client = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+        zip_filepath = f"{current_building_path}/bldg{building_id:07}-up{upgrade_id:02}.zip"
+        s3_client.download_file("oedi-data-lake", oedi_path, zip_filepath)
+        # Extract zip file
+        with zipfile.ZipFile(zip_filepath, "r") as zip_ref:
+            zip_ref.extract("in.xml",current_building_path)
+            if "schedules.csv" in zip_ref.namelist():
+                zip_ref.extract("schedules.csv",current_building_path)
+        os.remove(zip_filepath) # Remove zip file
+        os.rename(f"{current_building_path}/in.xml", f"{current_building_path}/bldg{building_id:07}-up{upgrade_id:02}_{date_string}.xml")
+        if os.path.exists(f"{current_building_path}/schedules.csv"):
+            os.rename(f"{current_building_path}/schedules.csv", f"{current_building_path}/bldg{building_id:07}-up{upgrade_id:02}_schedule_{date_string}.csv")
+
+
+def fetch_resstock_timeseries(
+        building_id:int,
+        upgrade_id:int,
+        state=str,
+        year=2022,
+        version="resstock_tmy3_release_1",
+):
+    """
+    fetch_resstock_timeseries: This function fetches previously performed ResStock simulations published by NREL. These files are filtered
+    by building number, upgrade id, state,
+
+    Author: Alex Lee (alexlee5124@gmail.com)
+    Date: 4/19/2025
+    """   
+
+    # Download timeseries data
+    oedi_path = "/".join(["nrel-pds-building-stock","end-use-load-profiles-for-us-building-stock",f"{year}",
+            f"{version}","timeseries_individual_buildings","by_state",f"upgrade={upgrade_id}",f"state={state}",f"{building_id}-{upgrade_id}.parquet",]) # AWS data access url
+    s3_client = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+    # Save downloaded file out to /ochre-sims/data/resstock_timeseries/state_year_version
+    building_data_path = os.path.join(os.path.dirname(os.path.dirname(os.getcwd())), f"data/resstock_timeseries/{state}_{year}_{version}/bldg{building_id:07}-up{upgrade_id:02}")
+    os.makedirs(building_data_path, exist_ok=True)
+    zip_filepath = f"{building_data_path}/{building_id}-{upgrade_id}.parquet"    # Save downloaded file out to /ochre-sims/data/resstock_timeseries/state_year_version
+    s3_client.download_file("oedi-data-lake", oedi_path, zip_filepath)
+    # Transcribe parquet file of the timeseries to a .csv file
+    resstock_df = Analysis.load_timeseries_file(f"{building_data_path}/{building_id}-{upgrade_id}.parquet")
+    resstock_df.reset_index().to_csv(f"{building_data_path}/resstock_timeseries_{building_id}-{upgrade_id}.csv", index=False)
+
+
+
+
+"""# Testing functionality
+if __name__ == '__main__':
+    # Example use
+    # Note there are more than 30,000 buildings in the upgrade list. Modify the code to only run a handful of times if looking to test functionality.
+    #fetch_building_xml(state="NY", upgrade=3,year=2022,version="resstock_amy2018_release_1.1")
+    fetch_resstock_timeseries(72,3,"NY",2022)"""
+

--- a/lib/fetch_resstock_data/resstock_lifeboat.py
+++ b/lib/fetch_resstock_data/resstock_lifeboat.py
@@ -1,0 +1,101 @@
+import subprocess
+import logging
+from typing import List
+from concurrent.futures import ThreadPoolExecutor
+import os
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Configuration
+SOURCE_BUCKET = "oedi-data-lake"
+DEST_BUCKET = "dummy-123-target"
+BASE_SOURCE_PATH = "nrel-pds-building-stock/end-use-load-profiles-for-us-building-stock/2022/resstock_amy2018_release_1.1/timeseries_individual_buildings/by_state"
+BASE_DEST_PATH = "resstock_lifeboat/resstock/2022/resstock_amy2018_release_1.1/timeseries_individual_buildings/by_state"
+AWS_PROFILE = "switchbox"  # Replace with your AWS profile name
+
+def construct_paths(state: str, upgrade: str) -> tuple:
+    """Construct source and destination paths for a given state and upgrade."""
+    source_path = f"s3://{SOURCE_BUCKET}/{BASE_SOURCE_PATH}/upgrade={upgrade}/state={state}/*"
+    dest_path = f"s3://{DEST_BUCKET}/{BASE_DEST_PATH}/upgrade={upgrade}/state={state}/"
+    return source_path, dest_path
+
+def copy_files(state: str, upgrade: str) -> bool:
+    """Copy files for a specific state and upgrade combination."""
+    source_path, dest_path = construct_paths(state, upgrade)
+    
+    command = [
+        "s5cmd",
+        "-v",
+        "--profile", AWS_PROFILE,
+        "cp",
+        source_path,
+        dest_path
+    ]
+    
+    try:
+        logger.info(f"Starting copy for state={state}, upgrade={upgrade}")
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True
+        )
+        logger.info(f"Successfully copied files for state={state}, upgrade={upgrade}")
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Error copying files for state={state}, upgrade={upgrade}: {e}")
+        logger.error(f"Command output: {e.output}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error for state={state}, upgrade={upgrade}: {e}")
+        return False
+
+def batch_copy(states: List[str], upgrades: List[str], max_workers: int = 3) -> None:
+    """
+    Execute copy operations for multiple states and upgrades in parallel.
+    
+    Args:
+        states: List of state codes (e.g., ['MA', 'CA'])
+        upgrades: List of upgrade values (e.g., ['0', '1'])
+        max_workers: Maximum number of concurrent copy operations
+    """
+    successful_copies = 0
+    failed_copies = 0
+    
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for state in states:
+            for upgrade in upgrades:
+                futures.append(
+                    executor.submit(copy_files, state, upgrade)
+                )
+        
+        for future in futures:
+            if future.result():
+                successful_copies += 1
+            else:
+                failed_copies += 1
+    
+    logger.info(f"Copy operations completed:")
+    logger.info(f"Successful copies: {successful_copies}")
+    logger.info(f"Failed copies: {failed_copies}")
+
+if __name__ == "__main__":
+    # Example usage
+    states_to_copy = ["IL", "NY"]  # Add your desired states
+    upgrades_to_copy = ["0", "3"]        # Add your desired upgrades
+    
+    # Ensure s5cmd is installed
+    try:
+        subprocess.run(["s5cmd", "--version"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        logger.error("s5cmd is not installed. Please install it first.")
+        exit(1)
+    
+    # Execute the batch copy
+    batch_copy(states_to_copy, upgrades_to_copy)


### PR DESCRIPTION
This branch is incubating the development a little library, complete with command line tool, that will make it easier to download subsets of data from buildstock. @alexhyunminlee has made a first stab at the tool, this blurb will describe the end state we're shooting for.

At a high-level, we're trying to do three things: 

1. Identify the set of bldg_ids within a given resstock or comstock release that belong to a given geography
2. Download datasets for those bldg_ids, locally or to a cloud bucket
3. Load dataset to a database, locally or to a cloud database

This library, which would be a stand alone python library, would be used in this repo to prepare data for ochre simulations, and would also be used in our reports data to download simulated load profiles for analysis, whether from NREL EULP or from our own OCHRE simulations.

What follows is an elaboration of those three steps, and what's left to do to implement them. Implementing them will be a team effort. at minimum, to unblock his work, @alexhyunminlee will make sure the tool can download hpxml/weather + 15 minute datasets to local disk (a subset of the dataset downloader tool), and @brmurray could add support for downloading metadata/hourly/yearly EULP (another subset of dataset downloader, 2.) as well as database loader (3.), and @alxsmith could help implement the geo-lookup (1.)

## 1. Find bldg_ids in a geography

There should be a function, exposed a command line tool, that takes a set of geographical designations from the user and outputs the set of bldg_ids in those areas.

These are some of the geographical variables we want to be able to use for sure:
- state
- puma (`in.puma`)
- city (`in.city`, though not every bldg_id is in a city)
- county
- electric utility territory
- gas utility territory

The last three are not available in ResStock, and would have to be inferred through GIS work. @alxsmith has already done some work in this area. Also, unless and until we find a national boundary dataset of electric and gas utilities, the last two will have to be added when we start working in a particular state.

In addition, ResStock units have the following geographically-flavored columns available which we may or may not want to use:

- `in.ahs_region` (i.e. `CBSA New York-Newark-Jersey City, NY-NJ-PA`)
- `in.census_division` (i.e. `Middle Atlantic`)
- `in.census_region` (i.e. `Northeast`)
- `in.ashrae_iecc_climate_zone_2004` (i.e. `5A`)
- `in.weather_file_city` (i.e. `New York La Guardia`)

Here's what's left to figure out:
- Function / CLI logic: you should be able to supply a list of items (say, a set of counties), but how do you combine different geo variables? Only allow the user to specify a state XOR a county? AND? OR?
- Decide which if any of the "extra" variables described above we want to support
- Decide which versions of comsstock / resstock we want initial support for (and provide error messages if user specifies a version that exists but is unsupported).
- Figure out which county every bldg_id is in (assuming this isn't in resstock already?? I see an `in.county` column but I'm not sure if @alxsmith added it.)
- Try to find national / electric utility territory boundaries, and if not, then add them for NY / IL / MA
- Figure out the implementation for this thing (The tool should probably just ship with a geo-crosswalk internally that maps bldg_ids in a given resstock/comstock version to these geographies, instead of needing to do any dynamic web lookups or GIS operations).

## 2. Download data for those bldg_ids

Next, there should be a function / CLI tool that takes in a set of bldg_ids (and the comstock / resstock version they refer to) and downloads user-specific data for those bldg_ids to a user-specific location, locally or in the cloud. This tool should be composable with the previous one, e.g.

`$ buildstock identify_buildings ... |  buildstock download_data ...`

Here are the raw datasets we want to be able to download for a given bldg_id from a given comstock/resstock version:
- HPXML file, for use with OCHRE (downloadable from NREL s3 bucket as an xml file)
  - Does ComStock also have HPXML files? If not, would need to alert the user.
- metadata file, for use analyzing ResStock EULP (downloadable from NREL s3 bucket as a csv file)
- weather file corresponding to the bldg_id (assuming it hasn't been downloaded already)
- annual EULP results (downloadable from NREL s3 bucket as a csv file)
- 15 minute EULP results (downloadable from NREL s3 bucket as a csv file)
- hourly EULP results (must be generated through Athena, then downloadable as parquet)
- monthly EULP results (must be generated through Athena, then downloadable as parquet)

So the user would need some easy way to specify which of those they want to download for a given bldg_id. Likely the function would be able to do this for a single bldg_id, and there would be another function that would call that function in parallel on a set of bldg_ids, and that other function would be exposed through a CLI.

Note that we'd be downloading the raw csv, parquet, etc. Loading into a database would be handled at the next step.

The user would also be able to specific the download location: a local directory, an S3 bucket, or a GCS bucket. In the simplest use case, you just want to download locally. But with large scale simulations, you'll want the data in the cloud. And we need to support both AWS and google cloud because Rewiring America using google cloud.

(Which reminds me, ultimately we'll want to add support for downloading load profiles generated by Rewiring America / Switchbox using EnergyPlus or OCHRE... but that's for a future release.)

What's left to do:
- Implement the `grab_single_bldgid_datasets` and `grab_list_of_bldgid_datasets` functions described above (there are three fetching modes: 1. grab a file directly (hpxml, metadata, annual, 15 minutes), 2. infer which file you need then grab it (parse hpxml to find corresponding weather file), and 3. generate the data via athena then download it (hourly, monthly load profiles)
- Figure out command line interface that doesn't get overwhelming (maybe let the user download hpxml+weather AND/OR metadata AND/OR one of 15min/hourly/monthly/annual load profiles)
- Implement support for S3 / GCS buckets
- Figure out how to lay out the downloaded data on disk in such as way that its easy for scripts to use and for the next tool to consume
- Harmomize downlo

## 3. Load dataset to a database, locally or in the cloud
For analysis purposes, this metadata and load profiles downloaded above (not the hpxml or weather files) are easier to deal with in a database than in raw form. Currently, we download the raw medata/load profile data from EULP and load it into duckdb as a single step, but these steps should actually be split up to maximize use cases.

Also, we'll want to do the same thing for any load profiles that we generate with OCHRE. So whatever nice database schema we land on for EULP metadata and load profiles should also be used for OCHRE load profiles, and this third tool should be able to load OCHRE load profiles into the db as well.

And eventually, we should support more than just duckdb, and probably add Redshift / BigQuery as well.

Remaining tasks here:
- Finalize a cohesive schema for EULP and OCHRE metadata and load profiles (that is consistent across supported resstock/comstock versions)
- Support loading OCHRE-generated load profiles (ideally this means our OCHRE outputs should have the same schema as the raw datasets for resstock/comstock EULP).
- Implement loading to duckdb (across supported resstock / comstock versions)
- Implement loading to cloud databases...

